### PR TITLE
lighten active tab color

### DIFF
--- a/themes/OneMonokai-color-theme.json
+++ b/themes/OneMonokai-color-theme.json
@@ -552,7 +552,7 @@
     "statusBarItem.hoverBackground": "#2c313a",
     "statusBar.noFolderBackground": "#21252B",
     "statusBar.debuggingBackground": "#21252B",
-    "tab.activeBackground": "#2c313a",
+    "tab.activeBackground": "#383E4A",
     "tab.border": "#181A1F",
     "tab.inactiveBackground": "#21252B",
     "titleBar.activeBackground": "#282c34",


### PR DESCRIPTION
This makes it a little more evident which tab is currently active.
The new color is the same as the one in `editor.lineHighlightBackground`.