### PR TITLE
Change diff colors for added/deleted hunks

### DIFF
--- a/themes/OneMonokai-color-theme.json
+++ b/themes/OneMonokai-color-theme.json
@@ -391,14 +391,14 @@
       "name": "diff.deleted",
       "scope": "markup.deleted",
       "settings": {
-        "foreground": "#c678dd"
+        "foreground": "#e06c75"
       }
     },
     {
       "name": "diff.inserted",
       "scope": "markup.inserted",
       "settings": {
-        "foreground": "#e5c07b"
+        "foreground": "#98c379"
       }
     },
     {


### PR DESCRIPTION
Currently these are purple for deleted text, and orange-yellow for inserted text.
This change uses a more common red-green scheme.

| Before | After |
| ------ | ----- |
| <img width="136" alt="Screenshot 2019-05-14 at 15 02 18" src="https://user-images.githubusercontent.com/478237/57704232-69296c00-7659-11e9-8d81-843316c44555.png"> | <img width="137" alt="Screenshot 2019-05-14 at 15 02 27" src="https://user-images.githubusercontent.com/478237/57704245-6e86b680-7659-11e9-9ad5-b41b58444b39.png"> |

These colors are visible, for example, in the diff underneath a commit message that's being edited using vscode (`git -c core.editor='code --wait' -c commit.verbose=true commit`), or when editing a hunk during staging in patch mode (`git -c core.editor='code --wait' add -p`, then <kbd>e</kbd>)

Unfortunately, these colors don't seem to be customizable via `settings.json` :( the [`diffEditor.*`](https://code.visualstudio.com/api/references/theme-color#diff-editor-colors) settings only apply to virtual editors (e.g. when clicking on an edited file in the git sidebar), and the [`gitDecoration.*`](https://code.visualstudio.com/api/references/theme-color#git-colors) are for the files themselves in the sidebar. (If anyone knows of a way to customize the hunk colors, I'm all ears!)