### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A cross between Monokai and One Dark theme
 
 ## Install
 
-press `ctl/command + shift + p` to launch the command palette then run
+press `ctl/command + p` to launch quick open then run
 ```
 ext install one-monokai
 ```


### PR DESCRIPTION
Ctl+shift+p opens the command palette
Ctl+p opens quick open
Commands like 'ext install' can only be run from quick open, or by opening the command palette and deleting the default '>' character. 
Changing the instructions to ctl + p leads to less confusion when unable to run a command.