### PR TITLE
Fix markdown code blocks

### DIFF
--- a/themes/OneMonokai-color-theme.json
+++ b/themes/OneMonokai-color-theme.json
@@ -567,7 +567,7 @@
     {
       "name": "Markup: Raw",
       "scope": [
-        "markup.raw.inline.markdown",
+        "markup.inline.raw",
         "markup.raw.block.markdown"
       ],
       "settings": {


### PR DESCRIPTION
For some reason, the markdown code blocks syntax highlighting was not working so I tried to fix it.

Before fix:
![Screen Shot 2021-11-09 at 09 59 31](https://user-images.githubusercontent.com/22667578/140896429-079db8a1-777c-4bb3-a915-cb6049d1156f.png)

After fix:
![Screen Shot 2021-11-09 at 10 00 49](https://user-images.githubusercontent.com/22667578/140896480-0b2c0243-bcfd-4ec9-9e39-e1aad855bd56.png)

