### PR TITLE
Theme `debugToolbar.background`

### DIFF
--- a/themes/OneMonokai-color-theme.json
+++ b/themes/OneMonokai-color-theme.json
@@ -7,6 +7,7 @@
     "activityBarBadge.background": "#528bff",
     "activityBarBadge.foreground": "#F8FAFD",
     "button.background": "#528bff",
+    "debugToolBar.background": "#2F333D",
     "diffEditor.insertedTextBackground": "#00809B33",
     "dropdown.background": "#1d1f23",
     "dropdown.border": "#181A1F",


### PR DESCRIPTION
Thank you for this extension! I happened to notice that the debug toolbar is not currently themed. Screenshot below is the current appearance on the left and the proposed change on the right:  

![image](https://user-images.githubusercontent.com/30305945/168957929-b393ac9d-40a5-42e9-a85d-5d16a4d1f31d.png)
